### PR TITLE
Matrix vector cleanup

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -12,12 +12,12 @@ sqerr_deriv(p::Number, y::Number) = 2(p - y)
 
 """Negative logistic sigmoid"""
 nlogsig(p::Number, y::Number)       = -log(sigmoid(-p * y))
-nlogsig_deriv(p::Number, y::Number) = y * (sigmoid(-p * y) - 1)
+nlogsig_deriv(p::Number, y::Number) = y * (sigmoid(-p * y) - one(p))
 
 """Heaviside step function"""
-heaviside(p::Number, y::Number) = p == y ? 0 : 1
+heaviside(p::Number, y::Number) = p == y ? zero(p) : one(p)
 
 """Sigmoid"""
-sigmoid(x::Number) = 1 / (1 + exp(-x))
+sigmoid(x::Number) = one(x) / (one(x) + exp(-x))
 
 end

--- a/src/evaluators.jl
+++ b/src/evaluators.jl
@@ -16,13 +16,13 @@ end
 const rmse = SquaredErrorEvaluator
 
 function evaluate{T<:PredictorTask}(evaluator::SquaredErrorEvaluator, predictor::FMPredictor{T}, 
-        X::FMMatrix, y::Array{FMFloat})
+        X::FMMatrix, y::Vector{FMFloat})
     predictions = zeros(X.n)
     evaluate!(evaluator, predictor, X, y, predictions)
 end
 
 function evaluate!{T<:PredictorTask}(evaluator::SquaredErrorEvaluator, predictor::FMPredictor{T}, 
-        X::FMMatrix, y::Array{FMFloat}, predictions::Array{FMFloat})
+        X::FMMatrix, y::Vector{FMFloat}, predictions::Vector{FMFloat})
     @time predict!(predictor, X, predictions)
     err = [Common.sqerr(predictions[i], y[i]) for i in 1:length(y)]
     evaluator.stat(err .* err)
@@ -36,13 +36,13 @@ end
 const heaviside = HeavisideEvaluator
 
 function evaluate{T<:PredictorTask}(evaluator::HeavisideEvaluator, predictor::FMPredictor{T}, 
-        X::FMMatrix, y::Array{FMFloat})
+        X::FMMatrix, y::Vector{FMFloat})
     predictions = zeros(X.n)
     evaluate!(evaluator, predictor, X, y, predictions)
 end
 
 function evaluate!{T<:PredictorTask}(evaluator::HeavisideEvaluator, predictor::FMPredictor{T}, 
-        X::FMMatrix, y::Array{FMFloat}, predictions::Array{FMFloat})
+        X::FMMatrix, y::Vector{FMFloat}, predictions::Vector{FMFloat})
     @time predict!(predictor, X, predictions)
     err = [Common.heaviside(predictions[i], y[i]) for i in 1:length(y)]
     evaluator.stat(err)

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -11,19 +11,19 @@ abstract MethodParams
 
 immutable SGDMethod <: MethodParams
   alpha::FMFloat
-  num_epochs::UInt
+  num_epochs::Int
 
   # regularization
   reg0::FMFloat
   regw::FMFloat
   regv::FMFloat
 
-  SGDMethod(; alpha::FMFloat = 0.01, num_epochs::UInt = UInt(100),
+  SGDMethod(; alpha::FMFloat = 0.01, num_epochs::Int = 100,
               reg0::FMFloat = .0, regw::FMFloat = .0, regv::FMFloat = .0) = new(alpha, num_epochs, reg0, regw, regv)
 end
 const sgd = SGDMethod
 
-function sgd_train!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Array{FMFloat})
+function sgd_train!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Vector{FMFloat})
    info("Learning Factorization Machines with gradient descent...")
    for epoch in 1:sgd.num_epochs
         #info("[SGD - Epoch $epoch] Start...")
@@ -32,12 +32,12 @@ function sgd_train!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, pred
    end
 end
 
-function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Array{FMFloat}, epoch::Integer, alpha::FMFloat)
+function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Vector{FMFloat}, epoch::Integer, alpha::FMFloat)
     predictions = zeros(length(y))
-    p = .0
-    f_sum = fill(.0, predictor.model.num_factors)
-    sum_sqr = fill(.0, predictor.model.num_factors)
-    mult = .0
+    p = zero(FMFloat)
+    f_sum = zeros(predictor.model.num_factors)
+    sum_sqr = zeros(predictor.model.num_factors)
+    mult = zero(FMFloat)
 
     for c in 1:X.n
         X_nzrange = nzrange(X, c)
@@ -55,7 +55,7 @@ function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, pred
     info("[SGD - Epoch $epoch] Evaluation: $evaluation")
 end
 
-function sgd_update!(sgd::SGDMethod, model::FMModel, alpha::FMFloat, idx::Array{Int64}, x::Array{FMFloat}, mult::FMFloat, f_sum::Array{FMFloat})
+function sgd_update!(sgd::SGDMethod, model::FMModel, alpha::FMFloat, idx::Vector{Int64}, x::Vector{FMFloat}, mult::FMFloat, f_sum::Vector{FMFloat})
     if model.k0
         model.w0 -= alpha * (mult + sgd.reg0 * model.w0)
     end

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -40,8 +40,9 @@ function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, pred
     mult = .0
 
     for c in 1:X.n
-        idx = X.rowval[X.colptr[c] : (X.colptr[c+1]-1)]
-        x = X.nzval[X.colptr[c] : (X.colptr[c+1]-1)]
+        X_nzrange = nzrange(X, c)
+        idx = X.rowval[X_nzrange]
+        x = X.nzval[X_nzrange]
         #info("DEBUG: processing $c")
         p = predict_instance!(predictor, idx, x, f_sum, sum_sqr)
         #info("DEBUG: prediction - p: $p, f_sum: $f_sum, sum_sqr: $sum_sqr")

--- a/src/models.jl
+++ b/src/models.jl
@@ -8,7 +8,7 @@ abstract ModelParams
 immutable GaussianModelParams <: ModelParams
     k0::Bool
     k1::Bool
-    num_factors::UInt
+    num_factors::Int
 
     mean::Float64
     stddev::Float64
@@ -17,7 +17,7 @@ immutable GaussianModelParams <: ModelParams
 end
 const gauss = GaussianModelParams
 
-function init(params::GaussianModelParams, X::FMMatrix, y::Array{FMFloat})
+function init(params::GaussianModelParams, X::FMMatrix, y::Vector{FMFloat})
     # initialization
     num_attributes, num_samples = size(X)
     # sanity check
@@ -37,18 +37,18 @@ type FMModel
     k1::Bool
 
     w0::FMFloat
-    w::Array{FMFloat, 1}
-    V::Array{FMFloat, 2}
+    w::Vector{FMFloat}
+    V::Matrix{FMFloat}
 
-    num_factors::UInt
+    num_factors::Int
 end
 
 function predict_instance!(model::FMModel, 
-                           idx::Array{Int64,1}, x::Array{FMFloat,1}, 
-                           f_sum::Array{FMFloat}, sum_sqr::Array{FMFloat})
+                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     fill!(f_sum, .0)
     fill!(sum_sqr, .0)
-    result = .0
+    result = zero(FMFloat)
     if model.k0
         result += model.w0
     end

--- a/src/predictors.jl
+++ b/src/predictors.jl
@@ -13,16 +13,16 @@ end
 
 """Instance prediction specialized for classification"""
 function predict_instance!(predictor::FMPredictor{ClassificationTask},
-                           idx::Array{Int64,1}, x::Array{FMFloat,1}, 
-                           f_sum::Array{FMFloat}, sum_sqr::Array{FMFloat})
+                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     p = predict_instance!(predictor.model, idx, x, f_sum, sum_sqr)
     sigmoid(p)
 end
 
 """Instance prediction specialized for regression"""
 function predict_instance!(predictor::FMPredictor{RegressionTask},
-                           idx::Array{Int64,1}, x::Array{FMFloat,1}, 
-                           f_sum::Array{FMFloat}, sum_sqr::Array{FMFloat})
+                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     p = predict_instance!(predictor.model, idx, x, f_sum, sum_sqr)
     max(min(p, predictor.task.target_max), predictor.task.target_min)
 end
@@ -35,13 +35,14 @@ function predict(predictor::FMPredictor, X::FMMatrix)
 end
 
 """Predicts labels for each column of `X` and stores the results into `result`"""
-function predict!(predictor::FMPredictor, X::FMMatrix, result::Array{FMFloat})
+function predict!(predictor::FMPredictor, X::FMMatrix, result::Vector{FMFloat})
     fill!(result, .0)
     f_sum = fill(.0, predictor.model.num_factors)
     sum_sqr = fill(.0, predictor.model.num_factors)
     for c in 1:X.n
-        idx = X.rowval[X.colptr[c] : (X.colptr[c+1]-1)]
-        x = X.nzval[X.colptr[c] : (X.colptr[c+1]-1)]
+        X_nzrange = nzrange(X, c)
+        idx = X.rowval[X_nzrange]
+        x = X.nzval[X_nzrange]
         result[c] = predict_instance!(predictor, idx, x, f_sum, sum_sqr)
     end
 end

--- a/src/tasks.jl
+++ b/src/tasks.jl
@@ -19,7 +19,7 @@ end
 """
 Given data `X` and `y`, initializes a `ClassificationTask`
 """
-function init(::ClassificationTaskParams, X::FMMatrix, y::Array{FMFloat, 1})
+function init(::ClassificationTaskParams, X::FMMatrix, y::Vector{FMFloat})
   ClassificationTask()
 end
 
@@ -43,7 +43,7 @@ end
 """
 Given data `X` and `y`, initializes a `RegressionTask`
 """
-function init(::RegressionTaskParams, X::FMMatrix, y::Array{FMFloat, 1})
+function init(::RegressionTaskParams, X::FMMatrix, y::Vector{FMFloat})
   RegressionTask(target_min = minimum(y), target_max = maximum(y))
 end
 

--- a/src/train.jl
+++ b/src/train.jl
@@ -4,8 +4,8 @@ using FactorizationMachines.Tasks: TaskParams
 using FactorizationMachines.Models: ModelParams 
 using FactorizationMachines.Predictors: FMPredictor
 
-function train(X::FMMatrix, y::Array{FMFloat}; 
-        method::SGDMethod         = Methods.sgd(alpha = 0.01, num_epochs = UInt(100), reg0 = .0, regv = .0, regw = .0),
+function train(X::FMMatrix, y::Vector{FMFloat}; 
+        method::SGDMethod         = Methods.sgd(alpha = 0.01, num_epochs = 100, reg0 = .0, regv = .0, regw = .0),
         evaluator::Evaluator      = Evaluators.rmse(),
         task_params::TaskParams   = Tasks.regression(),
         model_params::ModelParams = Models.gauss(k0 = true, k1 = true, num_factors = 8, mean = .0, stddev = .01))

--- a/test/ml100k.jl
+++ b/test/ml100k.jl
@@ -11,7 +11,7 @@ info("Test dim: $(size(ml100kTest))")
 
 info("Test ML-100K - Training model...")
 fmMl100k = @time train(ml100kTrain, ml100kTrainRatings, 
-        method = Methods.sgd(num_epochs = UInt(10), alpha = 0.1),
+        method = Methods.sgd(num_epochs = 10, alpha = 0.1),
         model_params = Models.gauss(num_factors = 4))
 #info("FM Model: $fmMl100k")
 info("Test ML-100K - Prediction over test dataset...")


### PR DESCRIPTION
Some matrix/vector cleanup tasks:
1. Use the sparse matrix API to iterate over the values/indices of sparse matrices: `nzrange`, `rowvals`, and `nzval`
2. Use `Vector` and `Matrix` instead of `Array{x, 1}` and `Array{x, 2}`
3. Use `zero(x)` and `one(x)` instead of `0` and `1` literals

Many of these changes are inspired by the [Performance tips](http://docs.julialang.org/en/release-0.4/manual/performance-tips/) section of the Julia manual.
