### PR TITLE
Subarray memory reduction

### DIFF
--- a/src/methods.jl
+++ b/src/methods.jl
@@ -23,16 +23,22 @@ immutable SGDMethod <: MethodParams
 end
 const sgd = SGDMethod
 
-function sgd_train!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Vector{FMFloat})
-   info("Learning Factorization Machines with gradient descent...")
-   for epoch in 1:sgd.num_epochs
+function sgd_train!{T<:PredictorTask}(
+    sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, 
+    X::FMMatrix, y::StridedVector{FMFloat})
+
+    info("Learning Factorization Machines with gradient descent...")
+    for epoch in 1:sgd.num_epochs
         #info("[SGD - Epoch $epoch] Start...")
         @time sgd_epoch!(sgd, evaluator, predictor, X, y, epoch, sgd.alpha)
         #info("[SGD - Epoch $epoch] End.")
-   end
+    end
 end
 
-function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, X::FMMatrix, y::Vector{FMFloat}, epoch::Integer, alpha::FMFloat)
+function sgd_epoch!{T<:PredictorTask}(
+        sgd::SGDMethod, evaluator::Evaluator, predictor::FMPredictor{T}, 
+        X::FMMatrix, y::StridedVector{FMFloat}, epoch::Integer, alpha::FMFloat)
+
     predictions = zeros(length(y))
     p = zero(FMFloat)
     f_sum = zeros(predictor.model.num_factors)
@@ -41,8 +47,8 @@ function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, pred
 
     for c in 1:X.n
         X_nzrange = nzrange(X, c)
-        idx = X.rowval[X_nzrange]
-        x = X.nzval[X_nzrange]
+        idx = sub(X.rowval, X_nzrange)
+        x = sub(X.nzval, X_nzrange)
         #info("DEBUG: processing $c")
         p = predict_instance!(predictor, idx, x, f_sum, sum_sqr)
         #info("DEBUG: prediction - p: $p, f_sum: $f_sum, sum_sqr: $sum_sqr")
@@ -55,7 +61,11 @@ function sgd_epoch!{T<:PredictorTask}(sgd::SGDMethod, evaluator::Evaluator, pred
     info("[SGD - Epoch $epoch] Evaluation: $evaluation")
 end
 
-function sgd_update!(sgd::SGDMethod, model::FMModel, alpha::FMFloat, idx::Vector{Int64}, x::Vector{FMFloat}, mult::FMFloat, f_sum::Vector{FMFloat})
+function sgd_update!(
+        sgd::SGDMethod, model::FMModel, alpha::FMFloat, 
+        idx::StridedVector{Int64}, x::StridedVector{FMFloat}, 
+        mult::FMFloat, f_sum::Vector{FMFloat})
+
     if model.k0
         model.w0 -= alpha * (mult + sgd.reg0 * model.w0)
     end

--- a/src/models.jl
+++ b/src/models.jl
@@ -44,7 +44,7 @@ type FMModel
 end
 
 function predict_instance!(model::FMModel, 
-                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           idx::StridedVector{Int64}, x::StridedVector{FMFloat}, 
                            f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     fill!(f_sum, .0)
     fill!(sum_sqr, .0)

--- a/src/predictors.jl
+++ b/src/predictors.jl
@@ -13,7 +13,7 @@ end
 
 """Instance prediction specialized for classification"""
 function predict_instance!(predictor::FMPredictor{ClassificationTask},
-                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           idx::StridedVector{Int64}, x::StridedVector{FMFloat}, 
                            f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     p = predict_instance!(predictor.model, idx, x, f_sum, sum_sqr)
     sigmoid(p)
@@ -21,7 +21,7 @@ end
 
 """Instance prediction specialized for regression"""
 function predict_instance!(predictor::FMPredictor{RegressionTask},
-                           idx::Vector{Int64}, x::Vector{FMFloat}, 
+                           idx::StridedVector{Int64}, x::StridedVector{FMFloat}, 
                            f_sum::Vector{FMFloat}, sum_sqr::Vector{FMFloat})
     p = predict_instance!(predictor.model, idx, x, f_sum, sum_sqr)
     max(min(p, predictor.task.target_max), predictor.task.target_min)
@@ -41,8 +41,8 @@ function predict!(predictor::FMPredictor, X::FMMatrix, result::Vector{FMFloat})
     sum_sqr = fill(.0, predictor.model.num_factors)
     for c in 1:X.n
         X_nzrange = nzrange(X, c)
-        idx = X.rowval[X_nzrange]
-        x = X.nzval[X_nzrange]
+        idx = sub(X.rowval, X_nzrange)
+        x = sub(X.nzval, X_nzrange)
         result[c] = predict_instance!(predictor, idx, x, f_sum, sum_sqr)
     end
 end


### PR DESCRIPTION
Reducing total memory usage from 329MB to 268MB for the `ml100k.jl` test by using `SubArray`s within Julia.

The problem is that given a matrix `X`, accessing a column or row of the matrix `X[:, c]` will allocate a completely new array with the contents of `X[:, c]`. Julia can avoid this by using subarrays which are views/references to the subarray with the matrix. To use a subarray and avoid memory allocation: `sub(X, :, c)`.

To support both types of `SubArray` and `DenseVector`, we convert some types to `StridedVector` which is essentially a union of the two.
