### PR TITLE
Fix negative log likelihood loss and its derivative and add unit tests

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -11,8 +11,8 @@ sqerr(p::Number, y::Number)       = (p - y)^2
 sqerr_deriv(p::Number, y::Number) = 2(p - y)
 
 """Negative logistic sigmoid"""
-nlogsig(p::Number, y::Number)       = -log(sigmoid(-p * y))
-nlogsig_deriv(p::Number, y::Number) = y * (sigmoid(-p * y) - one(p))
+nlogsig(p::Number, y::Number)       = -log(sigmoid(p * y))
+nlogsig_deriv(p::Number, y::Number) = y * sigmoid(p * y) - y
 
 """Heaviside step function"""
 heaviside(p::Number, y::Number) = p == y ? zero(p) : one(p)

--- a/test/test_common.jl
+++ b/test/test_common.jl
@@ -19,4 +19,20 @@ for i in 1:length(y)
   @test expected_loss[i] == Common.heaviside(yhat[i], y[i])
 end
 
+info("Testing negative logistic sigmoid loss for {1, -1} labels")
+y =  [1.0, 1.0, -1.0, -1.0]
+yhat = [1.0, -1.0, 1.0, -1.0]
+expected_loss = [-log(Common.sigmoid(1)), log(1 + e), log(1 + e), -log(Common.sigmoid(1))]
+for i in 1:length(y)
+  @test expected_loss[i] == Common.nlogsig(yhat[i], y[i])
+end
+
+info("Testing negative logistic sigmoid loss for {1, 0} labels")
+y =  [1.0, 1.0, 0.0, 0.0]
+yhat = [1.0, 0.0, 1.0, 0.0]
+expected_loss = [-log(Common.sigmoid(1)), log(2), log(2), log(2)]
+for i in 1:length(y)
+  @test expected_loss[i] == Common.nlogsig(yhat[i], y[i])
+end
+
 end


### PR DESCRIPTION
Looks like I was missing a negative sign on the derivative for `nlogsig_deriv`. Integrating this should give us `nlogsig`, the negative log likelihood.

Should be noted somewhere that labels are intended to be of the form `{-1, 1}` for correctness. Otherwise, we can transform the labels when the classification task is chosen.
